### PR TITLE
Update Migrator to latest API and fix multiple issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,12 @@
 
 ### Known issues
 
-- Bug with 429 rate limiting. The rate-limited request will still fail,
-  but subsequent requests will work.
 - Importing LD API TypeScript types causes an import error, so they are commented out
   in various spots.
 - Types in general are very loose, which Deno is not happy about. The scripts run as
   JavaScript overall instead of validating the TypeScript first.
 - Due to the current API configuration, you cannot have more than 20 environments in a single project.
 - Due to considerations around many API requests at once, monitor 400 errors for flag configurations that may not be up to date.
-- To avoid a race condition, a few `wait`s have been placed in the script.
 
 ## Things you Should Consider when migrating flags?
 

--- a/migrate.ts
+++ b/migrate.ts
@@ -84,18 +84,18 @@ consoleLogger(
 );
 await projResp.json();
 
-projRep.environments.items.forEach(async (env: any) => {
+for (const env of projRep.environments.items) {
   const segmentData = await getJson(
     `./source/project/${inputArgs.projKeySource}/segment-${env.key}.json`,
   );
   
   // We are ignoring big segments/synced segments for now
-  segmentData.items.forEach(async (segment: any) => {
+  for (const segment of segmentData.items) {
     if (segment.unbounded == true) {
       console.log(Colors.yellow(
         `Segment: ${segment.key} in Environment ${env.key} is unbounded, skipping`,
       ));
-      return;
+      continue;
     }
 
     const newSegment: any = {
@@ -150,13 +150,13 @@ projRep.environments.items.forEach(async (env: any) => {
       ),
     );
 
-    const segPatchStatus = await patchRules.statusText;
+    const segPatchStatus = patchRules.statusText;
     consoleLogger(
-      segPatchStatus,
+      patchRules.status,
       `Patching segment ${newSegment.key} status: ${segPatchStatus}`,
     );
-  });
-});
+  };
+};
 
 // Flag Data //
 const flagList: Array<string> = await getJson(
@@ -186,13 +186,13 @@ for (const [index, flagkey] of flagList.entries()) {
     description: flag.description
   };
 
-  if (flag.client_side_availability) {
-    newFlag.client_side_availability = flag.client_side_availability;
-  } else if (flag.include_in_snippet) {
-    newFlag.include_in_snippet = flag.include_in_snippet;
+  if (flag.clientSideAvailability) {
+    newFlag.clientSideAvailability = flag.clientSideAvailability;
+  } else if (flag.includeInSnippet) {
+    newFlag.includeInSnippet = flag.includeInSnippet;
   }
-  if (flag.custom_properties) {
-    newFlag.custom_properties = flag.custom_properties;
+  if (flag.customProperties) {
+    newFlag.customProperties = flag.customProperties;
   }
 
   if (flag.defaults) {

--- a/source.ts
+++ b/source.ts
@@ -3,7 +3,7 @@ import {
   ensureDir,
   ensureDirSync,
 } from "https://deno.land/std@0.149.0/fs/mod.ts";
-import { consoleLogger, ldAPIRequest, writeSourceData } from "./utils.ts";
+import { consoleLogger, delay, ldAPIRequest, writeSourceData } from "./utils.ts";
 
 interface Arguments {
   projKey: string;
@@ -16,6 +16,10 @@ let inputArgs: Arguments = yargs(Deno.args)
   .alias("k", "apikey")
   .alias("u", "domain")
   .default("u", "app.launchdarkly.com").argv;
+
+// ensure output directory exists
+const projPath = `./source/project/${inputArgs.projKey}`;
+ensureDirSync(projPath);
 
 // Project Data //
 const projResp = await fetch(
@@ -30,16 +34,19 @@ if (projResp == null) {
   Deno.exit(1);
 }
 const projData = await projResp.json();
-const projPath = `./source/project/${inputArgs.projKey}`;
-ensureDirSync(projPath); 
 
 await writeSourceData(projPath, "project", projData);
 
 // Segment Data //
 
 if (projData.environments.items.length > 0) {
+  
+  console.log(`Found ${projData.environments.items.length} environments`);
+
   projData.environments.items.forEach(async (env: any) => {
-    console.log(env.key);
+
+    console.log(`Getting Segments for environment: ${env.key}`);
+
     const segmentResp = await fetch(
       ldAPIRequest(
         inputArgs.apikey,
@@ -59,23 +66,76 @@ if (projData.environments.items.length > 0) {
   });
 }
 
-// Flag Data //
-const flagResp = await fetch(
-  ldAPIRequest(
-    inputArgs.apikey,
-    inputArgs.domain,
-    `flags/${inputArgs.projKey}?summary=false`,
-  ),
-);
-if (flagResp.status > 201) {
-  consoleLogger(flagResp.status, `Error getting flags: ${flagResp.status}`);
-  consoleLogger(flagResp.status, await flagResp.text());
-}
-if (flagResp == null) {
-  console.log("Failed getting Flags");
-  Deno.exit(1);
+// Get List of all Flags
+const pageSize : number = 5;
+let offset: number = 0;
+let moreFlags : boolean = true;
+const flags : string[] = [];
+let path = `flags/${inputArgs.projKey}?summary=true&limit=${pageSize}&offset=${offset}`;
+
+while (moreFlags) {
+
+  console.log(`Building flag list: ${offset} to ${offset + pageSize}`);
+
+  const flagsResp = await fetch(
+    ldAPIRequest(
+      inputArgs.apikey,
+      inputArgs.domain,
+      path,
+    ),
+  );
+
+  if (flagsResp.status > 201) {
+    consoleLogger(flagsResp.status, `Error getting flags: ${flagsResp.status}`);
+    consoleLogger(flagsResp.status, await flagsResp.text());
+  }
+  if (flagsResp == null) {
+    console.log("Failed getting Flags");
+    Deno.exit(1);
+  }
+
+  const flagsData = await flagsResp.json();
+
+  flags.push( ...flagsData.items.map((flag: any) => flag.key) );
+
+  if (flagsData._links.next) {
+    offset += pageSize;
+    path = `flags/${inputArgs.projKey}?summary=true&limit=${pageSize}&offset=${offset}`;
+  } else {
+    moreFlags = false;
+  }
 }
 
-const flagData = await flagResp.json();
+console.log(`Found ${flags.length} flags`);
 
-await writeSourceData(projPath, "flag", flagData);
+await writeSourceData(projPath, "flags", flags);
+
+// Get Individual Flag Data //
+ensureDirSync(`${projPath}/flags`);
+
+for (const [index, flagKey] of flags.entries()) {
+
+  console.log(`Getting flag ${index + 1} of ${flags.length}: ${flagKey}`)
+
+  await delay(200);
+
+  const flagResp = await fetch(
+    ldAPIRequest(
+      inputArgs.apikey,
+      inputArgs.domain,
+      `flags/${inputArgs.projKey}/${flagKey}`,
+    ),
+  );
+  if (flagResp.status > 201) {
+    consoleLogger(flagResp.status, `Error getting flag '${flagKey}': ${flagResp.status}`);
+    consoleLogger(flagResp.status, await flagResp.text());
+  }
+  if (flagResp == null) {
+    console.log("Failed getting flag '${flagKey}'");
+    Deno.exit(1);
+  }
+
+  const flagData = await flagResp.json();
+
+  await writeSourceData(`${projPath}/flags`, flagKey, flagData);
+}

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,7 @@
 import * as Colors from "https://deno.land/std/fmt/colors.ts";
 
+const apiVersion = "20240415";
+
 export async function getJson(filePath: string) {
   try {
     return JSON.parse(await Deno.readTextFile(filePath));
@@ -47,6 +49,7 @@ export function ldAPIPostRequest(
         "Content-Type": "application/json",
         'User-Agent': 'Project-Migrator-Script',
         "Authorization": apiKey,
+        "LD-API-Version": apiVersion,
       },
       body: JSON.stringify(body),
     },
@@ -67,6 +70,7 @@ export function ldAPIPatchRequest(
       headers: {
         "Content-Type": "application/json",
         "Authorization": apiKey,
+        "LD-API-Version": apiVersion,
       },
       body: JSON.stringify(body),
     },
@@ -114,6 +118,7 @@ export function ldAPIRequest(apiKey: string, domain: string, path: string) {
       headers: {
         "Authorization": apiKey,
         'User-Agent': 'launchdarkly-project-migrator-script',
+        "LD-API-Version": apiVersion,
       },
     },
   );

--- a/utils.ts
+++ b/utils.ts
@@ -10,6 +10,11 @@ export async function getJson(filePath: string) {
   }
 }
 
+export async function delay(ms: number) {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+
 export async function rateLimitRequest(req: Request, path: String) {
   const rateLimitReq = req.clone();
   const res = await fetch(req);

--- a/utils.ts
+++ b/utils.ts
@@ -133,7 +133,7 @@ export function ldAPIRequest(apiKey: string, domain: string, path: string) {
 
 async function writeJson(filePath: string, o: any) {
   try {
-    await Deno.writeTextFile(filePath, JSON.stringify(o));
+    await Deno.writeTextFile(filePath, JSON.stringify(o, null, 2));
   } catch (e) {
     console.log(e);
   }


### PR DESCRIPTION
This change updates the migrator to use the latest LD API version (20240415) making several changes:
- The source command now handles any number of flags, not up to 20
- The source command outputs an array of flag keys to `flags.json`
- Json files output are indented for easier inspection
- The source command outputs each flag individually to a flags subfolder and names them `<flagkey>.json`
- The above has the side-effect of fixing retrieval of environment settings for flags, which no longer happens by default in the newer API version for the Get Flag List endpoint, and is limited to just 3 environments even when they are specified. By using the individual Get Flag API, all environment details are retrieved.
- The rate limiting code has been fixed to respect the global and IP based rate limit headers, and it waits the appropriate amount of time.
- The migrate command outputs more detail on progress
- Several migrate steps were running concurrently causing potential race conditions, this has been changed to a fully sequential process
- Fix a bug where `clientSideAvailability` and `includeInSnippet` weren't being migrated.