### PR TITLE
Update migrate.ts

### DIFF
--- a/migrate.ts
+++ b/migrate.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import yargs from "https://cdn.deno.land/yargs/versions/yargs-v16.2.1-deno/raw/deno.ts";
+import yargs from "https://deno.land/x/yargs@v17.7.2-deno/deno.ts";
 import {
   buildPatch,
   buildRules,

--- a/source.ts
+++ b/source.ts
@@ -1,4 +1,4 @@
-import yargs from "https://cdn.deno.land/yargs/versions/yargs-v16.2.1-deno/raw/deno.ts";
+import yargs from "https://deno.land/x/yargs@v17.7.2-deno/deno.ts";
 import {
   ensureDir,
   ensureDirSync,


### PR DESCRIPTION
Current yargs import causes reference error as window global is not available in Deno 2. Updating yargs resolves this